### PR TITLE
fix: scrollbar lukker ikke lenger dropdown + søkefelt sticky

### DIFF
--- a/lib/DropDown/Dropdown.tsx
+++ b/lib/DropDown/Dropdown.tsx
@@ -1,5 +1,5 @@
 import styles from "./Dropdown.module.css";
-import { HTMLAttributes, ReactNode } from "react";
+import { forwardRef, HTMLAttributes, ReactNode } from "react";
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
@@ -8,23 +8,22 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   erApen: boolean;
 }
 
-const Dropdown = ({
-  erApen,
-  ariaLabel,
-  friKomponent,
-  children,
-  ...divProperties
-}: Props) => {
-  return erApen ? (
-    <div
-      role="dialog"
-      aria-label={ariaLabel}
-      className={`${styles.panel} ${friKomponent ? styles.panelFriKomponent : ""}`}
-      {...divProperties}
-    >
-      {children}
-    </div>
-  ) : null;
-};
+const Dropdown = forwardRef<HTMLDivElement, Props>(
+  ({ erApen, ariaLabel, friKomponent, children, ...divProperties }, ref) => {
+    return erApen ? (
+      <div
+        ref={ref}
+        role="dialog"
+        aria-label={ariaLabel}
+        className={`${styles.panel} ${friKomponent ? styles.panelFriKomponent : ""}`}
+        {...divProperties}
+      >
+        {children}
+      </div>
+    ) : null;
+  },
+);
+
+Dropdown.displayName = "Dropdown";
 
 export default Dropdown;

--- a/lib/Virksomhetsvelger/Virksomhetsvelger.module.css
+++ b/lib/Virksomhetsvelger/Virksomhetsvelger.module.css
@@ -72,6 +72,23 @@
 .popupHeader {
     display: flex;
     gap: 0.5rem;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background-color: var(--ax-bg-neutral-soft, var(--a-bg-subtle));
+    padding-bottom: var(--ax-space-8, var(--a-spacing-2));
+}
+
+.popupHeader input {
+    background-color: var(--ax-bg-default, var(--a-bg-default, white));
+}
+
+.popupHeader :global(.aksel-search__input) {
+    background-color: var(--ax-bg-default, var(--a-bg-default, white));
+}
+
+.popupHeader :global(.navds-search__input) {
+    background-color: var(--ax-bg-default, var(--a-bg-default, white));
 }
 
 

--- a/lib/Virksomhetsvelger/Virksomhetsvelger.tsx
+++ b/lib/Virksomhetsvelger/Virksomhetsvelger.tsx
@@ -16,6 +16,7 @@ const Velger = ({ friKomponent }: { friKomponent?: boolean }) => {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const valgtEnhetRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
   const [åpen, setÅpen] = useState<boolean>(false);
 
   const { søketekst, setSøketekst, valgtOrganisasjon, velgUnderenhet } =
@@ -89,6 +90,7 @@ const Velger = ({ friKomponent }: { friKomponent?: boolean }) => {
           ariaLabel="Virksomhetsvelger"
           friKomponent={true}
           erApen={åpen}
+          ref={dropdownRef}
         >
           <FocusTrap
             focusTrapOptions={{
@@ -100,6 +102,15 @@ const Velger = ({ friKomponent }: { friKomponent?: boolean }) => {
                 ) {
                   /**
                    * Knappen flipper også `åpen`. Om vi også flipper, så flippes `åpen` fram og tilbake.
+                   **/
+                } else if (
+                  dropdownRef.current &&
+                  e.target instanceof Node &&
+                  dropdownRef.current.contains(e.target)
+                ) {
+                  /**
+                   * Klikk på scrollbar treffer panel-elementet (utenfor FocusTrap).
+                   * Ikke lukk dropdown i dette tilfellet.
                    **/
                 } else {
                   setÅpen(false);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@navikt/virksomhetsvelger",
   "private": false,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",


### PR DESCRIPTION
Bug 1: Klikk på scrollbar trigget clickOutsideDeactivates i FocusTrap fordi scrollbaren tilhører panel-elementet (utenfor FocusTrap). Fix: Sjekk om klikket er innenfor dropdown-panelet før lukking.

Bug 2: Søkefeltet scrollet med listen, så AG med mange underenheter måtte scrolle til toppen for å søke igjen.
Fix: Gjør .popupHeader sticky øverst i scroll-containeren.